### PR TITLE
Add to translatable strings array

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,25 +4,18 @@ on: [push, pull_request]
 
 jobs:
   test:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            python: "3.7"
-          - os: windows-latest
-            python: "3.7"
-          - os: macos-latest
-            python: "3.11"
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.11
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.11
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,20 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        include:
+          - os: ubuntu-latest
+            python: "3.7"
+          - os: windows-latest
+            python: "3.7"
+          - os: macos-latest
+            python: "3.11"
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/nttt/tidyup.py
+++ b/nttt/tidyup.py
@@ -36,7 +36,7 @@ def revert_untranslatable_meta_elements(content, english_content):
     parsed_md = yaml_parser.load(content)
     english_parsed_md = yaml_parser.load(english_content)
 
-    translatable_keys = ["title", "description", "steps"]
+    translatable_keys = ["title", "description", "steps", "meta_title", "meta_description"]
     for key in parsed_md:
         if key not in translatable_keys and key in english_parsed_md:
             parsed_md[key] = english_parsed_md[key]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.26.4
 eol==0.9.0
 pandas==2.2.0
 ruamel.yaml==0.18.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.26.4
-eol==0.9.0
+eol==0.7.5
 pandas==2.2.0
 ruamel.yaml==0.18.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-eol==0.7.5
-pandas==1.5.0
-ruamel.yaml==0.17.21
+eol==0.9.0
+pandas==2.2.0
+ruamel.yaml==0.18.6

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ import os
 import setuptools
 
 if sys.version_info[0] == 2:
-    raise ValueError('This package requires Python 3.7 or newer')
+    raise ValueError('This package requires Python 3.11 or newer')
 elif sys.version_info[0] == 3:
-    if not sys.version_info >= (3, 7):
-        raise ValueError('This package requires Python 3.7 or newer')
+    if not sys.version_info >= (3, 11):
+        raise ValueError('This package requires Python 3.11 or newer')
 else:
     raise ValueError('Unrecognized major version of Python')
 
@@ -40,6 +40,6 @@ setuptools.setup(
         'eol',
         'ruamel.yaml',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.11',
     zip_safe=False
 )


### PR DESCRIPTION
Sasha's request to fix a part of the script:
https://raspberrypifoundation.slack.com/archives/C13FSSVDG/p1771346213669649

This was just a simple array change, but when pushing the PR, lots of the checks failed, I think due to Python being on an ancient version (v3.7).

Wasn't really sure what I was doing with the package/Python version wrangling but somehow downgrading to v0.7.5 of EOL helped - there didn't seem to exist a v0.9! (see https://github.com/trentm/eol/tags). I suppose we deploy and then check that the script is still working as intended 🤞 